### PR TITLE
Remove deprecated import

### DIFF
--- a/OpenInPS.lua
+++ b/OpenInPS.lua
@@ -46,7 +46,6 @@ Select the photo(s) you wish to export to Photoshop and select the desired desti
 local dt = require "darktable"
 local df = require "lib/dtutils.file"
 local dsys = require "lib/dtutils.system"
-require "official/yield"
 
 --Detect OS and modify accordingly--	
 op_sys = dt.configuration.running_os


### PR DESCRIPTION
When I run this script in debug mode I get the error "official/yield not found" on startup. Removing this line makes the script work again.